### PR TITLE
fix: missed vesselType definition for BSL-MPL-MK-1-CC-1

### DIFF
--- a/GameData/BetterScienceLabsContinued/Parts/Squad/Parts/BSLMPL-MK-1-CC-1/BSLMPL-MK-1-CC-1.cfg
+++ b/GameData/BetterScienceLabsContinued/Parts/Squad/Parts/BSLMPL-MK-1-CC-1/BSLMPL-MK-1-CC-1.cfg
@@ -41,6 +41,7 @@ PART
 	angularDrag = 2
 	crashTolerance = 6
 	maxTemp = 1200 // = 2900
+	vesselType = Ship
 	breakingForce = 50
 	breakingTorque = 50
 	childStageOffset = 1


### PR DESCRIPTION
### Description
This PR should fixes #10.

### Changes
* added missed `vesselType` definition in BSLMPL-MK-1-CC-1.cfg

Closes #10